### PR TITLE
Use add_metaclass instead of with_metaclass

### DIFF
--- a/pool/event.py
+++ b/pool/event.py
@@ -2,7 +2,7 @@
 
 from . import util, exc
 
-from six import with_metaclass
+from six import add_metaclass
 
 CANCEL = util.symbol('CANCEL')
 NO_RETVAL = util.symbol('NO_RETVAL')
@@ -154,7 +154,8 @@ def _remove_dispatcher(cls):
             if not _registrars[k]:
                 del _registrars[k]
 
-class Events(with_metaclass(_EventMeta, object)):
+@add_metaclass(_EventMeta)
+class Events(object):
     """Define event listening functions for a particular target type."""
 
     @classmethod


### PR DESCRIPTION
`with_metaclass` have some mro issue

```
  File "/workspace/dae/monkey.py", line 40, in patch_MySQLdb
    from pool.pool import QueuePool
  File "/workspace/venv/src/pool/pool/pool.py", line 22, in <module>
    from . import exc, log, event, events, interfaces
  File "/workspace/venv/src/pool/pool/event.py", line 157, in <module>
    class Events(with_metaclass(_EventMeta, object)):
  File "/workspace/venv/lib/python2.7/site-packages/six.py", line 617, in with_metaclass
    return meta("NewBase", bases, {})
  File "/workspace/venv/src/pool/pool/event.py", line 129, in __init__
    _create_dispatcher_class(cls, classname, bases, dict_)
  File "/workspace/venv/src/pool/pool/event.py", line 142, in _create_dispatcher_class
    dispatch_cls._listen = cls._listen
AttributeError: type object 'NewBase' has no attribute '_listen'
```
